### PR TITLE
feat: Show error from API and more details about the token

### DIFF
--- a/src/bdcli/commands/account/bdcli-account-sts-token.ts
+++ b/src/bdcli/commands/account/bdcli-account-sts-token.ts
@@ -15,12 +15,14 @@ const macroHeader = "\n-- BoilingData DuckDB Table Macro START\n";
 const macroFooter = "\n-- BoilingData DuckDB Table Macro END";
 const rcFilePath = path.join(process.env["HOME"] ?? "~", ".duckdbrc");
 
-function getMacro(token: string): string {
+function getMacro(token: string, shareId?: string): string {
+  const share = shareId ? `&shareId=${shareId}` : "";
   return (
     `${macroHeader}` +
     `CREATE OR REPLACE TEMP MACRO boilingdata(sql) AS TABLE ` +
     `SELECT * FROM parquet_scan('https://httpfs.api.test.boilingdata.com/httpfs?bdStsToken=` +
     token +
+    share +
     `&sql=' || sql);` +
     `${macroFooter}`
   );
@@ -57,7 +59,10 @@ async function show(options: any, _command: cmd.Command): Promise<void> {
     }
 
     if (options.duckdbMacro) {
-      await outputResults({ stsToken: bdStsToken, duckDbMacro: getMacro(bdStsToken) }, options.disableSpinner);
+      await outputResults(
+        { bdStsToken, duckDbMacro: getMacro(bdStsToken, options.shareId), ...rest },
+        options.disableSpinner,
+      );
     }
 
     if (options.duckdbrc) {
@@ -66,8 +71,8 @@ async function show(options: any, _command: cmd.Command): Promise<void> {
       const hasMacro = rcContents.includes(macroHeader);
       const regex = new RegExp(`${macroHeader}.*${macroFooter}`, "g");
       const newContents = hasMacro
-        ? rcContents.replace(regex, getMacro(bdStsToken))
-        : rcContents + "\n" + getMacro(bdStsToken);
+        ? rcContents.replace(regex, getMacro(bdStsToken, options.shareId))
+        : rcContents + "\n" + getMacro(bdStsToken, options.shareId);
       logger.debug({ rcContents, hasMacro, newContents, regex });
       await fs.writeFile(rcFilePath, newContents);
       spinnerSuccess();
@@ -80,7 +85,7 @@ async function show(options: any, _command: cmd.Command): Promise<void> {
     }
 
     if (!options.duckdbrc && !options.dbtprofiles && !options.duckdbMacro) {
-      await outputResults({ bdStsToken, ...rest }, options.disableSpinner);
+      await outputResults({ bdStsToken, cached: stsCached, ...rest }, options.disableSpinner);
     }
   } catch (err: any) {
     spinnerError(err?.message);

--- a/src/integration/boilingdata/account.ts
+++ b/src/integration/boilingdata/account.ts
@@ -6,6 +6,7 @@ import {
   updateConfig,
 } from "../../bdcli/utils/config_util.js";
 import { ILogger } from "../../bdcli/utils/logger_util.js";
+import { spinnerError } from "../../bdcli/utils/spinner_util.js";
 import { accountUrl, getReqHeaders, tokenShareUrl, tokenUrl } from "./boilingdata_api.js";
 import * as jwt from "jsonwebtoken";
 
@@ -108,17 +109,21 @@ export class BDAccount {
     this.logger.debug({ bdStsToken: this.selectedToken, decodedToken: this.decodedToken });
   }
 
-  private checkExp(exp: number): boolean {
+  private getHumanReadable(exp: number): string {
     const humanReadable = new Date();
+    humanReadable.setTime(exp * 1000);
+    return humanReadable.toISOString();
+  }
+
+  private checkExp(exp: number): boolean {
     const twoMinsAgo = new Date();
     twoMinsAgo.setTime(Date.now() - 2 * 60 * 1000);
-    humanReadable.setTime(exp * 1000);
     const diff = exp * 1000 - twoMinsAgo.getTime();
     this.logger.debug({
       exp,
       diff,
       twoMinsAgo: twoMinsAgo.toISOString(),
-      expReadable: humanReadable.toISOString(),
+      expiresIn: this.getHumanReadable(exp),
     });
     if (diff < 0) return false;
     return true;
@@ -179,11 +184,15 @@ export class BDAccount {
     throw new Error("Failed to unshare token");
   }
 
-  private async getTokenResp(shareId?: string): Promise<{ bdStsToken: string; cached: boolean } | undefined> {
+  private async getTokenResp(
+    shareId?: string,
+  ): Promise<{ bdStsToken: string; cached: boolean; expiresIn: string; tokenLifetimeMins: number } | undefined> {
     this.selectAndDecodeToken(shareId);
     this.dumpSelectedToken();
     if (!this.decodedToken || !this.selectedToken) throw new Error("Unable to select/decode token");
     const exp = this.decodedToken["payload"].exp;
+    const iat = this.decodedToken["payload"].iat;
+    const tokenLifetimeMins = Math.floor((exp - iat) / 60);
     if (exp && this.checkExp(exp)) {
       this.logger.debug({ cachedBdStstToken: true });
       // we clean up expired tokens at the same time
@@ -192,7 +201,7 @@ export class BDAccount {
       const credentials = { sharedTokens: serialiseTokensList(this.sharedTokens), bdStsToken: this.bdStsToken };
       await updateConfig({ credentials }); // local config file
       // NOTE: Even if the tokenLifetime would be different from the request, we return non-expired token
-      return { bdStsToken: this.selectedToken, cached: true };
+      return { bdStsToken: this.selectedToken, cached: true, expiresIn: this.getHumanReadable(exp), tokenLifetimeMins };
     }
     return; // expired
   }
@@ -230,6 +239,10 @@ export class BDAccount {
     this.logger.debug({ getStsToken: { body: resBody } });
     if (!resBody.ResponseCode || !resBody.ResponseText) {
       throw new Error("Malformed response from BD API");
+    }
+    if (resBody.ResponseCode != "00") {
+      spinnerError(resBody.ResponseText);
+      throw new Error(`Failed to fetch token: ${resBody.ResponseText}`);
     }
     if (!resBody.bdStsToken) {
       throw new Error("Missing bdStsToken in BD API Response");


### PR DESCRIPTION
Basic UX improvements. Show error details from API (e.g. invalid request parameters). Output more details about the token, like if using cached token, show its lifetime and expiration timestamp in UTC: